### PR TITLE
Exibir histórico da SQC na tela de produto

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,6 +26,7 @@
     "sonarjs/no-identical-expressions": "error",
     "react/require-default-props": "off",
     "import/prefer-default-export": "off",
+    "no-unused-vars": "warn",
     "react/jsx-filename-extension": "off",
     "react/function-component-definition": "off",
     "import/extensions": "off",

--- a/src/pages/projects/[projectId]/Project.tsx
+++ b/src/pages/projects/[projectId]/Project.tsx
@@ -12,7 +12,7 @@ import { useQuery } from './hooks/useQuery';
 import ProjectContent from '../components/ProjectContent';
 
 const Project: NextPageWithLayout = () => {
-  const { project } = useQuery();
+  const { project, repositoriesSqcHistory } = useQuery();
 
   return (
     <>
@@ -22,7 +22,10 @@ const Project: NextPageWithLayout = () => {
 
       <Container>
         <Box>
-          <ProjectContent project={project} />
+          <ProjectContent
+            project={project}
+            repositoriesSqcHistory={repositoriesSqcHistory}
+          />
         </Box>
       </Container>
     </>

--- a/src/pages/projects/[projectId]/hooks/useQuery.ts
+++ b/src/pages/projects/[projectId]/hooks/useQuery.ts
@@ -2,12 +2,14 @@ import { useEffect, useState } from 'react';
 
 import { useRouter } from 'next/router';
 
-import { Project } from '@customTypes/project';
+import { Project, RepositoriesSqcHistory } from '@customTypes/project';
 import { projectQuery } from '@services/project';
 
 export const useQuery = () => {
-  const { query } = useRouter();
   const [project, setProject] = useState<Project>();
+  const [repositoriesSqcHistory, setRepositoriesSqcHistory] = useState<RepositoriesSqcHistory>()
+
+  const { query } = useRouter();
 
   async function loadProject() {
     if (query?.projectId) {
@@ -20,9 +22,21 @@ export const useQuery = () => {
     }
   }
 
+  async function loadRepositoriesSqcHistory() {
+    if (query?.projectId) {
+      try {
+        const result = await projectQuery.getProductRepositoriesSqcHistory('1', query?.projectId as string);
+        setRepositoriesSqcHistory(result.data);
+      } catch (error) {
+        console.error(error);
+      }
+    }
+  }
+
   useEffect(() => {
     loadProject();
+    loadRepositoriesSqcHistory();
   }, [query?.projectId]);
 
-  return { project };
+  return { project, repositoriesSqcHistory };
 };

--- a/src/pages/projects/components/ProjectContent/ProjectContent.tsx
+++ b/src/pages/projects/components/ProjectContent/ProjectContent.tsx
@@ -5,7 +5,7 @@ import { ptBR } from 'date-fns/locale';
 
 import { Box, IconButton, Menu, MenuItem, Typography } from '@mui/material';
 
-import { Project } from '@customTypes/project';
+import { Project, RepositoriesSqcHistory } from '@customTypes/project';
 
 import Filters from '@components/Filters';
 
@@ -16,12 +16,14 @@ import { supportedEntitiesQuery } from '@services/supportedEntities';
 import { historical } from '@services/historicalCharacteristics';
 import axios from 'axios';
 import formatEntitiesFilter from '@utils/formatEntitiesFilter';
+import GraphicRepositoriesSqcHistory from '@components/GraphicRepositoriesSqcHistory';
 import Skeleton from '../Skeleton';
 
 import { BodyContainer, Circle, FiltersContainer, GraphicContainer } from './styles';
 
 interface Props {
   project?: Project;
+  repositoriesSqcHistory?: RepositoriesSqcHistory;
 }
 
 interface FilterProps {
@@ -31,7 +33,7 @@ interface FilterProps {
 
 const LARGE_PRIME_NUMBER = 907111937;
 
-const ProjectContent: React.FC<Props> = ({ project }) => {
+const ProjectContent: React.FC<Props> = ({ project, repositoriesSqcHistory }) => {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const openMenu = Boolean(anchorEl);
 
@@ -151,6 +153,8 @@ const ProjectContent: React.FC<Props> = ({ project }) => {
           </Menu>
         </Box>
       </Box>
+
+      <GraphicRepositoriesSqcHistory history={repositoriesSqcHistory} />
 
       <BodyContainer display="flex" width="100%" flexDirection="row">
         <FiltersContainer display="flex" width="30%" flexDirection="column">

--- a/src/shared/components/GraphicRepositoriesSqcHistory/GraphicRepositoriesSqcHistory.tsx
+++ b/src/shared/components/GraphicRepositoriesSqcHistory/GraphicRepositoriesSqcHistory.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import formatRepositoriesSqcHistory from '@utils/formatRepositoriesSqcHistory';
+import { RepositoriesSqcHistory } from '@customTypes/project';
+import ReactEcharts from 'echarts-for-react';
+import { GraphicContainer } from './styles';
+
+
+interface Props {
+  history: RepositoriesSqcHistory | undefined;
+}
+
+const GraphicRepositoriesSqcHistory = ({ history }: Props) => {
+  if (!history) {
+    return null;
+  }
+
+  const formatedOptions = formatRepositoriesSqcHistory(history);
+
+  return (
+    <GraphicContainer>
+        <ReactEcharts option={formatedOptions} style={{ height: '450px', width: '100%' }} />
+    </GraphicContainer>
+  );
+};
+
+export default GraphicRepositoriesSqcHistory;

--- a/src/shared/components/GraphicRepositoriesSqcHistory/index.ts
+++ b/src/shared/components/GraphicRepositoriesSqcHistory/index.ts
@@ -1,0 +1,1 @@
+export { default } from './GraphicRepositoriesSqcHistory';

--- a/src/shared/components/GraphicRepositoriesSqcHistory/styles.ts
+++ b/src/shared/components/GraphicRepositoriesSqcHistory/styles.ts
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+export const GraphicContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  padding: 1rem;
+  background-color: #f5f5fa;
+`;

--- a/src/shared/customTypes/project.ts
+++ b/src/shared/customTypes/project.ts
@@ -86,3 +86,21 @@ export interface ButtonType extends Omit<Partial<ButtonProps>, 'color'> {
   color: string;
   variant?: ButtonProps['variant'];
 }
+
+interface SqcValue {
+  id: number;
+  value: number;
+  created_at: string;
+}
+
+interface RepositoriesSqcHistoryResult {
+  id: number;
+  url: string;
+  name: string;
+  history: Array<SqcValue>
+}
+
+export interface RepositoriesSqcHistory {
+  count: number;
+  results: Array<RepositoriesSqcHistoryResult>
+}

--- a/src/shared/services/project.ts
+++ b/src/shared/services/project.ts
@@ -1,5 +1,5 @@
 /* eslint-disable class-methods-use-this */
-import { CurrentPreConfig, MeasuresHistory, ReleaseGoal } from '@customTypes/project';
+import { CurrentPreConfig, MeasuresHistory, ReleaseGoal, RepositoriesSqcHistory } from '@customTypes/project';
 import { Data } from '@customTypes/preConfig';
 import api from './api';
 
@@ -33,6 +33,11 @@ class ProjectQuery {
   async createProjectReleaseGoal(organizationId: string, projectId: string, data: ReleaseGoal) {
     const url = `organizations/${organizationId}/products/${projectId}/create/goal/`;
     return api.post(url, data);
+  }
+
+  async getProductRepositoriesSqcHistory(organizationId: string, productId: string) {
+    const url = `organizations/${organizationId}/products/${productId}/repositories-sqc-historical-values/`;
+    return api.get<RepositoriesSqcHistory>(url);
   }
 }
 

--- a/src/shared/utils/formatCharacteristicsHistory.ts
+++ b/src/shared/utils/formatCharacteristicsHistory.ts
@@ -35,7 +35,7 @@ const formatCharacteristicsHistory = (historical: Charactheristic[], checkedOpti
 
   return {
     title: {
-      text: 'Caracteristicas'
+      text: 'Características'
     },
     tooltip: {
       trigger: 'axis'

--- a/src/shared/utils/formatRepositoriesSqcHistory.ts
+++ b/src/shared/utils/formatRepositoriesSqcHistory.ts
@@ -1,0 +1,84 @@
+import { RepositoriesSqcHistory } from "@customTypes/project";
+import { format } from "date-fns";
+
+const longestHistoryMetricsIndex = (sqcHistoryResults: RepositoriesSqcHistory['results']) =>
+  sqcHistoryResults.reduce((prevIndex, historyResult, currentIndex) => {
+    const previousMetricHistoryLength = sqcHistoryResults[prevIndex].history.length;
+    const currentMetricHistoryLength = historyResult.history.length;
+
+    return currentMetricHistoryLength > previousMetricHistoryLength ? currentIndex : prevIndex;
+  }, 0);
+
+const formatTwoDecimalPlaces = (value: number) => Math.round(value * 100) / 100;
+
+const formatRepositoriesSqcHistory = (history: RepositoriesSqcHistory) => {
+  const legendData: string[] = [];
+
+  const xAxisData = history.results[longestHistoryMetricsIndex(history.results)].history.map((metric) =>
+    format(new Date(metric.created_at.replace(/\s+/g, '')), 'dd/MM/yyyy HH:MM')
+  );
+
+  const series = history.results.map((item) => {
+    legendData.push(item.name);
+
+    return {
+      name: item.name,
+      data: item.history.map((metric) => formatTwoDecimalPlaces(metric.value)),
+      type: 'line',
+      animationDuration: 1200
+    };
+  });
+
+  return {
+    title: {
+      text: 'Comportamento observado do produto',
+    },
+    tooltip: {
+      trigger: 'axis'
+    },
+    legend: {
+      data: legendData.flatMap(i => [i,i]),
+      top: 40
+    },
+    grid: {
+      left: '3%',
+      right: '4%',
+      bottom: '12%',
+      top: '25%',
+      containLabel: true
+    },
+    toolbox: {
+      feature: {
+        saveAsImage: {},
+        dataZoom: {
+          yAxisIndex: 'none'
+        },
+        restore: {}
+      }
+    },
+    dataZoom: [
+      {
+        type: 'inside',
+        start: xAxisData.length - 20,
+        end: xAxisData.length - 1
+      },
+      {
+        start: xAxisData.length - 20,
+        end: xAxisData.length - 1
+      }
+    ],
+    xAxis: {
+      type: 'category',
+      data: xAxisData,
+      axisLabel: {
+        rotate: 45
+      }
+    },
+    yAxis: {
+      type: 'value'
+    },
+    series
+  };
+};
+
+export default formatRepositoriesSqcHistory;


### PR DESCRIPTION
## Motivação

[#274](https://github.com/fga-eps-mds/2022-1-MeasureSoftGram-Doc/issues/274)

Visualizar histórico da SQC na tela de produto

## Mudanças

<!-- In the changelog section, you can add the changes in an objective way -->

- Adiciona função e tipos para buscar dados da API
- Cria componente para renderizar grafico
- Adiciona novo componente na tela de produto

## Status Checklist

<!-- In the status section, you can mark what you have already done -->

- [ ] Test
- [ ] Lint
- [ ] Development

## Screenshots

<!-- If you are adding a layout change, you can show the images below -->

![image](https://user-images.githubusercontent.com/37983059/189541085-7e272a6a-3843-4771-a705-4a8338ee023d.png) 

## Execução


- Acesse a página url /projects/3
