### PR TITLE
Arrumando bug nos filtros de características

### DIFF
--- a/src/shared/components/Filters/Filters.tsx
+++ b/src/shared/components/Filters/Filters.tsx
@@ -36,7 +36,7 @@ const Filters: React.FC<FiltersProps> = ({ filterTitle, options = [], updateOpti
         <Styles.OptionContainer display="flex" flexDirection="column">
           {options.map((option) => (
             <Styles.Option key={option} display="flex" flexDirection="row" alignItems="center">
-              <Checkbox onChange={() => handleUpdate(option)} />
+              <Checkbox checked={checkedOptions[option]} onChange={() => handleUpdate(option)} />
               <span>{option[0].toUpperCase() + option.slice(1).replace('_', ' ')}</span>
             </Styles.Option>
           ))}


### PR DESCRIPTION
## Motivação

Quando o usuário fechava o filtro de características e abria de novo, por exemplo, o comportamento do filtro ficava invertido causando confusão na experiência do usuário. 

Resolves [#289](https://github.com/fga-eps-mds/2022-1-MeasureSoftGram-Doc/issues/289)

## Mudanças

A partir de agora o comportamento dos filtros se mantém mesmo abrindo e fechando as entidades dos filtros.

## Status Checklist

<!-- In the status section, you can mark what you have already done -->

- [ ] Test
- [ ] Lint
- [ ] Development

